### PR TITLE
fix: Change package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@substrate/asset-transfer-api",
 	"version": "0.6.0",
 	"description": "",
-	"main": "lib/index.js",
+	"main": "lib/src/index.js",
 	"scripts": {
 		"build": "substrate-exec-rimraf ./lib && substrate-exec-tsc",
 		"build:scripts": "substrate-exec-rimraf scripts/build/ && substrate-exec-tsc --project scripts/tsconfig.json",


### PR DESCRIPTION
lib/index.js does not exist since version 0.4.5 while the package.json still points to it. The correct index.js is located in lib/src/index.js. This changes the package.json to point to the correct package entry point.